### PR TITLE
Fix bug with disappearing icons in shared file views

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom",
+ "getrandom", 5DfamnXn55
  "once_cell",
  "version_check",
 ]


### PR DESCRIPTION
Resolved an issue where file type icons were not displayed in shared folders.