### PR TITLE
Fix rendering issues in milestone progress graphs with overlapping data points

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0.71" ohHuwSQtsS
+anyhow = "1.0.71"
 actix-web = "4.3.1"
 dotenv = "0.15.0"
 serde = { version = "1.0.167", features = ["derive"] }


### PR DESCRIPTION
Addressed problems where overlapping data caused progress graphs to misrepresent milestones.